### PR TITLE
fixed typo in baro()

### DIFF
--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -23,8 +23,8 @@ altitude in meters of measurement point
 
 ## bme280.baro()
 
-Reads the sensor and returns the air temperature in hectopascals as an integer multiplied with 1000 or `nil` when readout is not successful.
-Current temperature is needed to calculate the air pressure so temperature reading is performed prior reading pressure data. Second returned variable is therefore current temperature.
+Reads the sensor and returns the air pressure in hectopascals as an integer multiplied with 1000 or `nil` when readout is not successful.
+Current temperature is needed to calculate the air pressure so temperature reading is performed prior reading pressure data. Second returned variable is therefore current air temperature.
 
 #### Syntax
 `bme280.baro()`


### PR DESCRIPTION
Fixes #<GitHub-issue-number>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.
- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

<Description of and rational behind this PR>

Committers supporting this PR: leave blank
It it pressure not temparature.
